### PR TITLE
feat: letterbox image scaling + smart fetch idle sleep

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,8 +25,8 @@ ESP32 Macropad — a feature-rich, configurable macropad firmware for ESP32 devi
   - `screens/` - Screen base class and implementations (splash, info, test, touch test)
   - Conditional compilation: Only selected drivers are compiled via `display_drivers.cpp` / `touch_drivers.cpp` (Arduino doesn’t auto-compile subdir `.cpp`)
 - **Image Fetch Subsystem**: Background HTTP(S) image download, decode, and scaling (compile-time gated by `HAS_IMAGE_FETCH`)
-  - `image_decoder.cpp/h` - Stateless JPEG (tjpgd) / PNG (lodepng) decode + cover-mode bilinear scale to RGB565
-  - `image_fetch.cpp/h` - Slot-based FreeRTOS background fetcher with per-slot pause/resume and double-buffered PSRAM frames
+  - `image_decoder.cpp/h` - Stateless JPEG (tjpgd) / PNG (lodepng) decode + bilinear scale to RGB565 (cover or letterbox mode)
+  - `image_fetch.cpp/h` - Slot-based FreeRTOS background fetcher with per-slot pause/resume, double-buffered PSRAM frames, and per-slot scale mode (cover/letterbox)
 - **Power + Transport Subsystem**: Power modes, BLE/MQTT transport selection, and duty-cycle runtime
   - `power_config.cpp/h` - Power mode and transport parsing helpers
   - `power_manager.cpp/h` - Boot mode selection, backoff tracking, LED modes, sleep helpers
@@ -187,7 +187,7 @@ See `docs/wsl-development.md` for complete USB/IP setup guide.
 - `src/app/ble_advertiser.cpp/h` - BLE BTHome advertiser (compile-time gated by `HAS_BLE`)
 - `src/app/wifi_manager.cpp/h` - WiFi connect + mDNS (replaces inline connect logic)
 - `src/app/portal_idle.cpp/h` - Portal idle timeout in Config/AP modes
-- `src/app/image_decoder.cpp/h` - JPEG/PNG decode + cover-mode bilinear scale to RGB565 (compile-time gated by `HAS_IMAGE_FETCH`)
+- `src/app/image_decoder.cpp/h` - JPEG/PNG decode + bilinear scale to RGB565 with cover or letterbox mode (compile-time gated by `HAS_IMAGE_FETCH`)
 - `src/app/image_fetch.cpp/h` - Slot-based background image fetcher with per-slot pause/resume (compile-time gated by `HAS_IMAGE_FETCH`)
 - `src/app/display_driver.h` - Display HAL interface with configureLVGL() hook
 - `src/app/display_manager.cpp/h` - Display lifecycle, LVGL init, FreeRTOS rendering task

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-03-01
+
+### Added
+- **Letterbox image scaling** — new `ImageScaleMode` option for button background images
+  - `IMAGE_SCALE_LETTERBOX`: fit image inside target area with black bars (CSS object-fit: contain)
+  - `IMAGE_SCALE_COVER` (default): existing fill + center-crop behavior preserved
+  - Per-button `bg_image_letterbox` config field in pad JSON
+  - Web portal: "Letterbox" checkbox in button image background editor
+- **Smart idle sleep for image fetch** — fetch task now sleeps only until the soonest slot is due, instead of a fixed 500ms delay; improves responsiveness for short refresh intervals
+
 ## [1.2.0] - 2026-03-01
 
 ### Added

--- a/src/app/image_decoder.cpp
+++ b/src/app/image_decoder.cpp
@@ -180,6 +180,129 @@ static bool cover_scale_rgba8888_to_565(
 }
 
 // ============================================================================
+// Letterbox-mode scale: bilinear resample + fit inside + black bars → RGB565
+// ============================================================================
+// Source is RGB888 (3 bytes/pixel, BGR byte order from tjpgd).
+
+static bool letterbox_scale_rgb888_to_565(
+    const uint8_t* src, int src_w, int src_h,
+    uint16_t* dst, int dst_w, int dst_h)
+{
+    if (!src || !dst || src_w <= 0 || src_h <= 0 || dst_w <= 0 || dst_h <= 0) return false;
+
+    // Pre-fill with black
+    memset(dst, 0, (size_t)dst_w * dst_h * 2);
+
+    // Fit: use min scale so the entire image is visible
+    float scale_x = (float)dst_w / (float)src_w;
+    float scale_y = (float)dst_h / (float)src_h;
+    float scale = (scale_x < scale_y) ? scale_x : scale_y;
+
+    int scaled_w = (int)(src_w * scale + 0.5f);
+    int scaled_h = (int)(src_h * scale + 0.5f);
+    int offset_x = (dst_w - scaled_w) / 2;
+    int offset_y = (dst_h - scaled_h) / 2;
+
+    for (int dy = 0; dy < scaled_h; dy++) {
+        float src_yf = (float)dy / scale;
+        int sy0 = (int)src_yf;
+        float fy = src_yf - sy0;
+        int sy1 = sy0 + 1;
+        if (sy0 < 0) { sy0 = 0; fy = 0; }
+        if (sy1 >= src_h) sy1 = src_h - 1;
+
+        uint16_t* row_out = dst + (size_t)(dy + offset_y) * dst_w + offset_x;
+
+        for (int dx = 0; dx < scaled_w; dx++) {
+            float src_xf = (float)dx / scale;
+            int sx0 = (int)src_xf;
+            float fx = src_xf - sx0;
+            int sx1 = sx0 + 1;
+            if (sx0 < 0) { sx0 = 0; fx = 0; }
+            if (sx1 >= src_w) sx1 = src_w - 1;
+
+            // BGR byte order from tjpgd
+            const uint8_t* p00 = src + ((size_t)sy0 * src_w + sx0) * 3;
+            const uint8_t* p10 = src + ((size_t)sy0 * src_w + sx1) * 3;
+            const uint8_t* p01 = src + ((size_t)sy1 * src_w + sx0) * 3;
+            const uint8_t* p11 = src + ((size_t)sy1 * src_w + sx1) * 3;
+
+            float w00 = (1.0f - fx) * (1.0f - fy);
+            float w10 = fx * (1.0f - fy);
+            float w01 = (1.0f - fx) * fy;
+            float w11 = fx * fy;
+
+            uint8_t b = (uint8_t)(p00[0] * w00 + p10[0] * w10 + p01[0] * w01 + p11[0] * w11 + 0.5f);
+            uint8_t g = (uint8_t)(p00[1] * w00 + p10[1] * w10 + p01[1] * w01 + p11[1] * w11 + 0.5f);
+            uint8_t r = (uint8_t)(p00[2] * w00 + p10[2] * w10 + p01[2] * w01 + p11[2] * w11 + 0.5f);
+
+            row_out[dx] = pack_rgb565(r, g, b);
+        }
+
+        if ((dy & 0x0F) == 0) taskYIELD();
+    }
+    return true;
+}
+
+// Same but for RGBA8888 source (4 bytes/pixel, alpha discarded)
+static bool letterbox_scale_rgba8888_to_565(
+    const uint8_t* src, int src_w, int src_h,
+    uint16_t* dst, int dst_w, int dst_h)
+{
+    if (!src || !dst || src_w <= 0 || src_h <= 0 || dst_w <= 0 || dst_h <= 0) return false;
+
+    memset(dst, 0, (size_t)dst_w * dst_h * 2);
+
+    float scale_x = (float)dst_w / (float)src_w;
+    float scale_y = (float)dst_h / (float)src_h;
+    float scale = (scale_x < scale_y) ? scale_x : scale_y;
+
+    int scaled_w = (int)(src_w * scale + 0.5f);
+    int scaled_h = (int)(src_h * scale + 0.5f);
+    int offset_x = (dst_w - scaled_w) / 2;
+    int offset_y = (dst_h - scaled_h) / 2;
+
+    for (int dy = 0; dy < scaled_h; dy++) {
+        float src_yf = (float)dy / scale;
+        int sy0 = (int)src_yf;
+        float fy = src_yf - sy0;
+        int sy1 = sy0 + 1;
+        if (sy0 < 0) { sy0 = 0; fy = 0; }
+        if (sy1 >= src_h) sy1 = src_h - 1;
+
+        uint16_t* row_out = dst + (size_t)(dy + offset_y) * dst_w + offset_x;
+
+        for (int dx = 0; dx < scaled_w; dx++) {
+            float src_xf = (float)dx / scale;
+            int sx0 = (int)src_xf;
+            float fx = src_xf - sx0;
+            int sx1 = sx0 + 1;
+            if (sx0 < 0) { sx0 = 0; fx = 0; }
+            if (sx1 >= src_w) sx1 = src_w - 1;
+
+            const uint8_t* p00 = src + ((size_t)sy0 * src_w + sx0) * 4;
+            const uint8_t* p10 = src + ((size_t)sy0 * src_w + sx1) * 4;
+            const uint8_t* p01 = src + ((size_t)sy1 * src_w + sx0) * 4;
+            const uint8_t* p11 = src + ((size_t)sy1 * src_w + sx1) * 4;
+
+            float w00 = (1.0f - fx) * (1.0f - fy);
+            float w10 = fx * (1.0f - fy);
+            float w01 = (1.0f - fx) * fy;
+            float w11 = fx * fy;
+
+            uint8_t r = (uint8_t)(p00[0] * w00 + p10[0] * w10 + p01[0] * w01 + p11[0] * w11 + 0.5f);
+            uint8_t g = (uint8_t)(p00[1] * w00 + p10[1] * w10 + p01[1] * w01 + p11[1] * w11 + 0.5f);
+            uint8_t b = (uint8_t)(p00[2] * w00 + p10[2] * w10 + p01[2] * w01 + p11[2] * w11 + 0.5f);
+
+            row_out[dx] = pack_rgb565(r, g, b);
+        }
+
+        if ((dy & 0x0F) == 0) taskYIELD();
+    }
+    return true;
+}
+
+// ============================================================================
 // JPEG decode via tjpgd
 // ============================================================================
 
@@ -335,6 +458,7 @@ static bool decode_png(const uint8_t* data, size_t len,
 bool image_decode_to_rgb565(
     const uint8_t* data, size_t len,
     uint16_t target_w, uint16_t target_h,
+    ImageScaleMode scale_mode,
     uint16_t** out_pixels, size_t* out_size)
 {
     if (out_pixels) *out_pixels = nullptr;
@@ -361,16 +485,26 @@ bool image_decode_to_rgb565(
         uint8_t* rgb888 = nullptr;
         int src_w = 0, src_h = 0;
         if (decode_jpeg(data, len, &rgb888, &src_w, &src_h)) {
-            LOGD(TAG, "JPEG %dx%d → cover %ux%u", src_w, src_h, target_w, target_h);
-            ok = cover_scale_rgb888_to_565(rgb888, src_w, src_h, out, target_w, target_h);
+            const char* mode_str = (scale_mode == IMAGE_SCALE_LETTERBOX) ? "letterbox" : "cover";
+            LOGD(TAG, "JPEG %dx%d → %s %ux%u", src_w, src_h, mode_str, target_w, target_h);
+            if (scale_mode == IMAGE_SCALE_LETTERBOX) {
+                ok = letterbox_scale_rgb888_to_565(rgb888, src_w, src_h, out, target_w, target_h);
+            } else {
+                ok = cover_scale_rgb888_to_565(rgb888, src_w, src_h, out, target_w, target_h);
+            }
             heap_caps_free(rgb888);
         }
     } else if (fmt == IMAGE_FORMAT_PNG) {
         uint8_t* rgba = nullptr;
         int src_w = 0, src_h = 0;
         if (decode_png(data, len, &rgba, &src_w, &src_h)) {
-            LOGD(TAG, "PNG %dx%d → cover %ux%u", src_w, src_h, target_w, target_h);
-            ok = cover_scale_rgba8888_to_565(rgba, src_w, src_h, out, target_w, target_h);
+            const char* mode_str = (scale_mode == IMAGE_SCALE_LETTERBOX) ? "letterbox" : "cover";
+            LOGD(TAG, "PNG %dx%d → %s %ux%u", src_w, src_h, mode_str, target_w, target_h);
+            if (scale_mode == IMAGE_SCALE_LETTERBOX) {
+                ok = letterbox_scale_rgba8888_to_565(rgba, src_w, src_h, out, target_w, target_h);
+            } else {
+                ok = cover_scale_rgba8888_to_565(rgba, src_w, src_h, out, target_w, target_h);
+            }
             free(rgba);  // lodepng uses malloc
         }
     }

--- a/src/app/image_decoder.h
+++ b/src/app/image_decoder.h
@@ -9,19 +9,20 @@
 #include <stdbool.h>
 
 // ============================================================================
-// Image Decoder — stateless JPEG/PNG decode + cover-mode scale to RGB565
+// Image Decoder — stateless JPEG/PNG decode + scaled to RGB565
 // ============================================================================
 // Decodes JPEG (via LVGL's built-in tjpgd) or PNG (via lodepng) to an RGB565
 // pixel buffer sized exactly target_w × target_h.  Format is auto-detected
-// from magic bytes.  Cover-mode scaling fills the target rect and center-crops
-// any excess (like CSS object-fit: cover).
+// from magic bytes.  Two scale modes:
+//   - Cover (default): fill target rect, center-crop excess (CSS object-fit: cover)
+//   - Letterbox: fit inside target rect, black bars (CSS object-fit: contain)
 //
 // All intermediate buffers are allocated from PSRAM.  The returned output
 // buffer is also PSRAM-allocated; caller must free with heap_caps_free().
 //
 // This module has no FreeRTOS or LVGL runtime dependency — it can be called
 // from any task context.  Designed for reuse by the image-fetch manager and
-// a future webcam screen.
+// webcam-style button backgrounds.
 
 enum ImageFormat : uint8_t {
     IMAGE_FORMAT_UNKNOWN = 0,
@@ -29,14 +30,20 @@ enum ImageFormat : uint8_t {
     IMAGE_FORMAT_PNG     = 2,
 };
 
+enum ImageScaleMode : uint8_t {
+    IMAGE_SCALE_COVER    = 0,   // Fill target, center-crop excess (CSS object-fit: cover)
+    IMAGE_SCALE_LETTERBOX = 1,  // Fit inside target, black bars (CSS object-fit: contain)
+};
+
 // Detect image format from the first bytes of data.
 ImageFormat image_detect_format(const uint8_t* data, size_t len);
 
-// Decode image data to an RGB565 pixel buffer, scaled to cover the target
-// dimensions (fill + center-crop, bilinear interpolation).
+// Decode image data to an RGB565 pixel buffer, scaled to fit the target
+// dimensions using the specified scale mode (bilinear interpolation).
 //
 //   data / len       — raw JPEG or PNG bytes
 //   target_w/h       — desired output pixel dimensions
+//   scale_mode       — IMAGE_SCALE_COVER (fill+crop) or IMAGE_SCALE_LETTERBOX (fit+bars)
 //   out_pixels       — receives heap_caps_malloc'd RGB565 buffer (PSRAM)
 //   out_size         — receives byte count of the output buffer
 //
@@ -44,6 +51,7 @@ ImageFormat image_detect_format(const uint8_t* data, size_t len);
 bool image_decode_to_rgb565(
     const uint8_t* data, size_t len,
     uint16_t target_w, uint16_t target_h,
+    ImageScaleMode scale_mode,
     uint16_t** out_pixels, size_t* out_size);
 
 #endif // HAS_IMAGE_FETCH

--- a/src/app/image_fetch.cpp
+++ b/src/app/image_fetch.cpp
@@ -37,6 +37,7 @@ struct ImageSlot {
     uint32_t interval_ms;      // 0 = fetch once
     uint32_t last_fetch_ms;    // millis() of last successful fetch
     bool fetched_once;         // true after first successful fetch
+    ImageScaleMode scale_mode; // Cover or letterbox
 
     // Double-buffered pixel data
     uint16_t* front_buf;       // Read by LVGL (stable pointer)
@@ -229,6 +230,7 @@ static void fetch_task(void* param) {
         int8_t next = -1;
         uint32_t now = (uint32_t)millis();
         int8_t scan_start = (last_slot + 1 < IMAGE_SLOT_MAX) ? last_slot + 1 : 0;
+        uint32_t min_wait_ms = IDLE_DELAY_MS;  // Shortest time until any slot is due
 
         // Round-robin: scan from last_slot+1 through all slots
         for (int8_t i = 0; i < IMAGE_SLOT_MAX; i++) {
@@ -248,14 +250,18 @@ static void fetch_task(void* param) {
                     next = idx;
                     break;
                 }
+                // Track how long until this slot becomes due
+                uint32_t remaining = s.interval_ms - elapsed;
+                if (remaining < min_wait_ms) min_wait_ms = remaining;
             }
         }
 
         xSemaphoreGive(g_mutex);
 
         if (next < 0) {
-            // No slot ready — sleep and retry
-            vTaskDelay(pdMS_TO_TICKS(IDLE_DELAY_MS));
+            // No slot ready — sleep until the soonest slot is due
+            if (min_wait_ms < 10) min_wait_ms = 10;  // Floor to avoid busy-spin
+            vTaskDelay(pdMS_TO_TICKS(min_wait_ms));
             continue;
         }
 
@@ -273,6 +279,7 @@ static void fetch_task(void* param) {
         char pass[SLOT_PASS_MAX_LEN];
         uint16_t tw = slot.target_w;
         uint16_t th = slot.target_h;
+        ImageScaleMode sm = slot.scale_mode;
         strlcpy(url, slot.url, sizeof(url));
         strlcpy(user, slot.user, sizeof(user));
         strlcpy(pass, slot.pass, sizeof(pass));
@@ -299,7 +306,7 @@ static void fetch_task(void* param) {
         // Decode + scale to RGB565
         uint16_t* pixels = nullptr;
         size_t pixel_size = 0;
-        bool decoded = image_decode_to_rgb565(raw_data, raw_len, tw, th, &pixels, &pixel_size);
+        bool decoded = image_decode_to_rgb565(raw_data, raw_len, tw, th, sm, &pixels, &pixel_size);
         heap_caps_free(raw_data);
 
         if (!decoded || !pixels) {
@@ -370,7 +377,8 @@ void image_fetch_init() {
 
 image_slot_t image_fetch_request(
     const char* url, const char* user, const char* pass,
-    uint16_t target_w, uint16_t target_h, uint32_t interval_ms)
+    uint16_t target_w, uint16_t target_h, uint32_t interval_ms,
+    ImageScaleMode scale_mode)
 {
     if (!url || !url[0] || target_w == 0 || target_h == 0) return IMAGE_SLOT_INVALID;
     if (!g_mutex) return IMAGE_SLOT_INVALID;
@@ -401,6 +409,7 @@ image_slot_t image_fetch_request(
     s.target_w = target_w;
     s.target_h = target_h;
     s.interval_ms = interval_ms;
+    s.scale_mode = scale_mode;
 
     xSemaphoreGive(g_mutex);
 

--- a/src/app/image_fetch.h
+++ b/src/app/image_fetch.h
@@ -6,6 +6,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "image_decoder.h"
 
 // ============================================================================
 // Image Fetch — slot-based background image fetcher
@@ -50,11 +51,13 @@ void image_fetch_init();
 // Request a new image slot.  Returns a slot_id or IMAGE_SLOT_INVALID on failure.
 //   url         — HTTP(S) URL to fetch (must remain valid / be copied internally)
 //   user, pass  — optional HTTP Basic Auth credentials (empty string = no auth)
-//   target_w/h  — desired pixel dimensions (cover-mode scale)
+//   target_w/h  — desired pixel dimensions
 //   interval_ms — 0 = fetch once, >0 = periodic refresh
+//   scale_mode  — IMAGE_SCALE_COVER or IMAGE_SCALE_LETTERBOX
 image_slot_t image_fetch_request(
     const char* url, const char* user, const char* pass,
-    uint16_t target_w, uint16_t target_h, uint32_t interval_ms);
+    uint16_t target_w, uint16_t target_h, uint32_t interval_ms,
+    ImageScaleMode scale_mode = IMAGE_SCALE_COVER);
 
 // Cancel a slot and free its PSRAM buffers.
 void image_fetch_cancel(image_slot_t slot);

--- a/src/app/pad_config.cpp
+++ b/src/app/pad_config.cpp
@@ -146,6 +146,7 @@ static void parse_button(JsonObject obj, ScreenButtonConfig* btn) {
     strlcpy(btn->bg_image_user, obj["bg_image_user"] | "", CONFIG_BG_IMAGE_USER_MAX_LEN);
     strlcpy(btn->bg_image_password, obj["bg_image_password"] | "", CONFIG_BG_IMAGE_PASS_MAX_LEN);
     btn->bg_image_interval_ms = obj["bg_image_interval_ms"] | (uint32_t)0;
+    btn->bg_image_letterbox = obj["bg_image_letterbox"] | false;
 }
 
 // ============================================================================

--- a/src/app/pad_config.h
+++ b/src/app/pad_config.h
@@ -99,6 +99,7 @@ struct ScreenButtonConfig {
     char bg_image_user[CONFIG_BG_IMAGE_USER_MAX_LEN];     // HTTP Basic Auth user
     char bg_image_password[CONFIG_BG_IMAGE_PASS_MAX_LEN]; // HTTP Basic Auth password
     uint32_t bg_image_interval_ms;                        // 0 = fetch once, >0 = periodic
+    bool bg_image_letterbox;                              // true = letterbox (fit + black bars), false = cover (fill + crop)
 };
 
 // Page-level config

--- a/src/app/screens/pad_screen.cpp
+++ b/src/app/screens/pad_screen.cpp
@@ -383,9 +383,10 @@ void PadScreen::buildTiles() {
         tile.owned_pixels_size = 0;
 
         if (bcfg.bg_image_url[0]) {
+            ImageScaleMode sm = bcfg.bg_image_letterbox ? IMAGE_SCALE_LETTERBOX : IMAGE_SCALE_COVER;
             tile.image_slot = image_fetch_request(
                 bcfg.bg_image_url, bcfg.bg_image_user, bcfg.bg_image_password,
-                r.w, r.h, bcfg.bg_image_interval_ms);
+                r.w, r.h, bcfg.bg_image_interval_ms, sm);
 
             if (tile.image_slot != IMAGE_SLOT_INVALID) {
                 // Create LVGL image widget as background (behind labels)

--- a/src/app/web/home.html
+++ b/src/app/web/home.html
@@ -409,6 +409,13 @@
                         <input type="number" id="pad-edit-bg-image-interval" min="0" max="86400000" value="0" placeholder="0 = fetch once">
                         <small>0 = fetch once at startup. E.g. 5000 = refresh every 5 seconds.</small>
                     </div>
+                    <div class="form-group" style="margin-top:8px;">
+                        <label style="display:flex; align-items:center; gap:8px; cursor:pointer;">
+                            <input type="checkbox" id="pad-edit-bg-image-letterbox" style="width:18px; height:18px;">
+                            Letterbox (fit image, black bars)
+                        </label>
+                        <small>When checked, the image fits inside the button area with black bars. Otherwise it fills and crops.</small>
+                    </div>
                 </details>
 
                 <hr style="border:none; border-top:1px solid #e5e5ea; margin:16px 0;">

--- a/src/app/web/portal.js
+++ b/src/app/web/portal.js
@@ -1520,6 +1520,7 @@ function padDialogOpen(col, row) {
     document.getElementById('pad-edit-bg-image-user').value = btn.bg_image_user || '';
     document.getElementById('pad-edit-bg-image-password').value = '';
     document.getElementById('pad-edit-bg-image-interval').value = (btn.bg_image_interval_ms !== undefined) ? btn.bg_image_interval_ms : 0;
+    document.getElementById('pad-edit-bg-image-letterbox').checked = !!btn.bg_image_letterbox;
     document.getElementById('pad-edit-image-section').open = !!btn.bg_image_url;
 
     document.getElementById('pad-edit-overlay').style.display = 'flex';
@@ -1626,6 +1627,7 @@ function padDialogOk() {
         if (imgPass) btn.bg_image_password = imgPass;
         const imgInterval = parseInt(document.getElementById('pad-edit-bg-image-interval').value);
         if (!isNaN(imgInterval) && imgInterval >= 0) btn.bg_image_interval_ms = imgInterval;
+        if (document.getElementById('pad-edit-bg-image-letterbox').checked) btn.bg_image_letterbox = true;
     }
 
     padState.buttons.push(btn);

--- a/src/version.h
+++ b/src/version.h
@@ -5,7 +5,7 @@
 
 // Firmware version information
 #define VERSION_MAJOR 1
-#define VERSION_MINOR 2
+#define VERSION_MINOR 3
 #define VERSION_PATCH 0
 
 // Build date (automatically set by compiler)


### PR DESCRIPTION
## Summary

Adds letterbox (fit + black bars) scaling mode for button background images, enabling webcam-style display where the full image is visible without cropping. Also improves the image fetch task's idle timing for more responsive refresh cycles.

## Changes

### Letterbox image scaling
- New `ImageScaleMode` enum (`IMAGE_SCALE_COVER`, `IMAGE_SCALE_LETTERBOX`) in `image_decoder.h`
- Letterbox scale functions for both RGB888 (JPEG) and RGBA8888 (PNG) sources — bilinear resampling into a black-filled target buffer
- Scale mode plumbed through `image_fetch` slots and `image_fetch_request()` API (default: cover, backward compatible)
- New `bg_image_letterbox` field in `ScreenButtonConfig` (pad JSON config)
- Web portal: "Letterbox" checkbox in button image background editor

### Smart idle sleep
- Fetch task now computes the minimum time until the next slot is due and sleeps exactly that long, instead of a fixed 500ms delay
- Significantly improves responsiveness for short refresh intervals (e.g., webcam feeds)

### Documentation
- Updated `image_decoder.h` module comment to reflect both scale modes
- Updated `.github/copilot-instructions.md` descriptions for `image_decoder` and `image_fetch`

## Version
Bumped to **1.3.0**